### PR TITLE
README: Use HTTPS for all resources that support it

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This README documents
 
 `period` must be one of `last-day`, `last-week` or `last-month`, and `count` is the 
 number of packages to show. `count` can be at most 100 currently. Example output for
-`http://cranlogs.r-pkg.org/top/last-day/3`
+`https://cranlogs.r-pkg.org/top/last-day/3`
 
 ```js
 {
@@ -94,36 +94,36 @@ If there was no package given, then that key is missing.
 
 All packages, last day:
 
-> [`http://cranlogs.r-pkg.org/downloads/total/last-day`](http://cranlogs.r-pkg.org/downloads/total/last-day)
+> [`https://cranlogs.r-pkg.org/downloads/total/last-day`](https://cranlogs.r-pkg.org/downloads/total/last-day)
 
 All packages, specific date:
 
-> [`http://cranlogs.r-pkg.org/downloads/total/2014-02-01`](http://cranlogs.r-pkg.org/downloads/total/2014-02-01)
+> [`https://cranlogs.r-pkg.org/downloads/total/2014-02-01`](https://cranlogs.r-pkg.org/downloads/total/2014-02-01)
 
 
 Package `ggplot2`, last week:
 
-> [`http://cranlogs.r-pkg.org/downloads/total/last-week/ggplot2`](http://cranlogs.r-pkg.org/downloads/total/last-week/ggplot2)
+> [`https://cranlogs.r-pkg.org/downloads/total/last-week/ggplot2`](https://cranlogs.r-pkg.org/downloads/total/last-week/ggplot2)
 
 
 Package `ggplot2`, given 7-day period:
 
-> [`http://cranlogs.r-pkg.org/downloads/total/2014-02-01:2014-02-08/ggplot2`](http://cranlogs.r-pkg.org/downloads/total/2014-02-01:2014-02-08/ggplot2)
+> [`https://cranlogs.r-pkg.org/downloads/total/2014-02-01:2014-02-08/ggplot2`](https://cranlogs.r-pkg.org/downloads/total/2014-02-01:2014-02-08/ggplot2)
 
 
 Package `ggplot2`, last 30 days:
 
-> [`http://cranlogs.r-pkg.org/downloads/total/last-month/ggplot2`](http://cranlogs.r-pkg.org/downloads/total/last-month/ggplot2)
+> [`https://cranlogs.r-pkg.org/downloads/total/last-month/ggplot2`](https://cranlogs.r-pkg.org/downloads/total/last-month/ggplot2)
 
 
 Package "ggplot2", specific month:
 
-> [`http://cranlogs.r-pkg.org/downloads/total/2014-01-01:2014-01-31/ggplot2`](http://cranlogs.r-pkg.org/downloads/total/2014-01-01:2014-01-31/ggplot2)
+> [`https://cranlogs.r-pkg.org/downloads/total/2014-01-01:2014-01-31/ggplot2`](https://cranlogs.r-pkg.org/downloads/total/2014-01-01:2014-01-31/ggplot2)
 
 
 Multiple packages at once:
 
-> [`http://cranlogs.r-pkg.org/downloads/total/last-day/igraph,ggplot2,Rcpp`](http://cranlogs.r-pkg.org/downloads/total/last-day/igraph,ggplot2,Rcpp)
+> [`https://cranlogs.r-pkg.org/downloads/total/last-day/igraph,ggplot2,Rcpp`](https://cranlogs.r-pkg.org/downloads/total/last-day/igraph,ggplot2,Rcpp)
 
 
 #### Accepted values
@@ -167,22 +167,22 @@ Again, if no package was specified, then that key is missing.
 
 Downloads per day, last 7 days:
 
-> [`http://cranlogs.r-pkg.org/downloads/daily/last-week`](http://cranlogs.r-pkg.org/downloads/daily/last-week)
+> [`https://cranlogs.r-pkg.org/downloads/daily/last-week`](https://cranlogs.r-pkg.org/downloads/daily/last-week)
 
 
 Downloads per day, specific 7 days:
 
-> [`http://cranlogs.r-pkg.org/downloads/daily/2014-02-07:2014-02-14`](http://cranlogs.r-pkg.org/downloads/daily/2014-02-07:2014-02-14)
+> [`https://cranlogs.r-pkg.org/downloads/daily/2014-02-07:2014-02-14`](https://cranlogs.r-pkg.org/downloads/daily/2014-02-07:2014-02-14)
 
 
 Downloads per day, last 30 days:
 
-> [`http://cranlogs.r-pkg.org/downloads/daily/last-month/ggplot2`](http://cranlogs.r-pkg.org/downloads/daily/last-month/ggplot2)
+> [`https://cranlogs.r-pkg.org/downloads/daily/last-month/ggplot2`](https://cranlogs.r-pkg.org/downloads/daily/last-month/ggplot2)
 
 
 Downloads per day, specific 30 day period:
 
-> [`http://cranlogs.r-pkg.org/downloads/daily/2014-01-03:2014-02-03/ggplot2`](http://cranlogs.r-pkg.org/downloads/daily/2014-01-03:2014-02-03/ggplot2)
+> [`https://cranlogs.r-pkg.org/downloads/daily/2014-01-03:2014-02-03/ggplot2`](https://cranlogs.r-pkg.org/downloads/daily/2014-01-03:2014-02-03/ggplot2)
 
 ### Downloads of R
 
@@ -193,11 +193,11 @@ operating systems and R versions. Here are some examples:
 
 Last day, separately for R versions and operating systems:
 
-> [`http://cranlogs.r-pkg.org/downloads/daily/last-day/R`](http://cranlogs.r-pkg.org/downloads/daily/last-day/R)
+> [`https://cranlogs.r-pkg.org/downloads/daily/last-day/R`](https://cranlogs.r-pkg.org/downloads/daily/last-day/R)
 
 Total number of downloads last week:
 
-> [`http://cranlogs.r-pkg.org/downloads/total/last-week/R`](http://cranlogs.r-pkg.org/downloads/total/last-week/R)
+> [`https://cranlogs.r-pkg.org/downloads/total/last-week/R`](https://cranlogs.r-pkg.org/downloads/total/last-week/R)
 
 
 ## Badges 
@@ -208,29 +208,29 @@ Returns an SVG badge with download counts. Monthly, weekly and daily
 summaries and the total number of downloads are available.
 If the summary type is not given, the number of downloads per month is shown:
 
-> `http://cranlogs.r-pkg.org/badges/Rcpp`
+> `https://cranlogs.r-pkg.org/badges/Rcpp`
 >
-> ![](http://cranlogs.r-pkg.org/badges/Rcpp)
+> ![](https://cranlogs.r-pkg.org/badges/Rcpp)
 
 Weekly downloads are shown with `last-week`:
 
-> `http://cranlogs.r-pkg.org/badges/last-week/Rcpp`
+> `https://cranlogs.r-pkg.org/badges/last-week/Rcpp`
 >
-> ![](http://cranlogs.r-pkg.org/badges/last-week/Rcpp)
+> ![](https://cranlogs.r-pkg.org/badges/last-week/Rcpp)
 
 Daily downloads are shown with `last-day`:
 
-> `http://cranlogs.r-pkg.org/badges/last-day/Rcpp`
+> `https://cranlogs.r-pkg.org/badges/last-day/Rcpp`
 >
-> ![](http://cranlogs.r-pkg.org/badges/last-day/Rcpp)
+> ![](https://cranlogs.r-pkg.org/badges/last-day/Rcpp)
 
 Total number of downloads since October of 2012, the month the
-[RStudio CRAN mirror](http://cran-logs.rstudio.com/) started publishing
+[RStudio CRAN mirror](https://cran-logs.rstudio.com/) started publishing
 logs, with `grand-total`:
 
-> `http://cranlogs.r-pkg.org/badges/grand-total/Rcpp`
+> `https://cranlogs.r-pkg.org/badges/grand-total/Rcpp`
 >
-> ![](http://cranlogs.r-pkg.org/badges/grand-total/Rcpp)
+> ![](https://cranlogs.r-pkg.org/badges/grand-total/Rcpp)
 
 Colors can be customized. Supported color names are:
 `brightgreen`, `green`, `yellowgreen`, `yellow`, `orange`,
@@ -238,16 +238,16 @@ Colors can be customized. Supported color names are:
 The badge is blue by default, as above. Other colors in
 the same order, and the hex color `ff69b4`:
 
-> `http://cranlogs.r-pkg.org/badges/Rcpp?color=brightgreen`
+> `https://cranlogs.r-pkg.org/badges/Rcpp?color=brightgreen`
 >
-> ![](http://cranlogs.r-pkg.org/badges/Rcpp?color=brightgreen)
-> ![](http://cranlogs.r-pkg.org/badges/Rcpp?color=green)
-> ![](http://cranlogs.r-pkg.org/badges/Rcpp?color=yellowgreen)
-> ![](http://cranlogs.r-pkg.org/badges/Rcpp?color=yellow)
-> ![](http://cranlogs.r-pkg.org/badges/Rcpp?color=orange)
-> ![](http://cranlogs.r-pkg.org/badges/Rcpp?color=red)
-> ![](http://cranlogs.r-pkg.org/badges/Rcpp?color=lightgrey)
-> ![](http://cranlogs.r-pkg.org/badges/Rcpp?color=ff69b4)
+> ![](https://cranlogs.r-pkg.org/badges/Rcpp?color=brightgreen)
+> ![](https://cranlogs.r-pkg.org/badges/Rcpp?color=green)
+> ![](https://cranlogs.r-pkg.org/badges/Rcpp?color=yellowgreen)
+> ![](https://cranlogs.r-pkg.org/badges/Rcpp?color=yellow)
+> ![](https://cranlogs.r-pkg.org/badges/Rcpp?color=orange)
+> ![](https://cranlogs.r-pkg.org/badges/Rcpp?color=red)
+> ![](https://cranlogs.r-pkg.org/badges/Rcpp?color=lightgrey)
+> ![](https://cranlogs.r-pkg.org/badges/Rcpp?color=ff69b4)
 
-Our badges were designed and created by [shields.io](http://shields.io).
+Our badges were designed and created by [shields.io](https://shields.io).
 


### PR DESCRIPTION
An extension of #31 that includes the README file. Note that cran-logs.rstudio.com does not appear to be available over HTTPS at the moment.